### PR TITLE
bootstrap regression

### DIFF
--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object LibDependencies {
-  val bootstrapVersion = "10.1.0"
+  val bootstrapVersion = "9.19.0"
   private val playHmrcFrontendVersion = "12.8.0"
   private val webchatVersion = "1.8.0"
 


### PR DESCRIPTION
regression of bootstrap to 9.19.0 to avoid forcing an update of the ui-test-runner which breaks everything.