### PR TITLE
DDCNL-12070: Breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,26 @@ anything (e.g button position on the menu bar, href links, button names etc. can
 
 `runTests.sh` and `publishLocal.sh` are provided to quickly test and publish versions of the library for Play 3.0.
 
+## Migrating to the next major version
+### hideMenuBar removed
+The menu is now shown/hidden automatically based on auth state set by WrapperDataAttributesFilter.
+
+- If you passed hideMenuBar = true for unauthenticated pages: no action needed, this is now automatic.
+- If you passed hideMenuBar = true on an authenticated page: this is no longer supported — the menu will always show for authenticated users.
+### timeOutUrl and keepAliveUrl removed as parameters
+- These are now read from config only. Remove them from your standardScaLayout() call.
+
+### showBackLinkJS / backLinkUrl replaced by BackLinkConfig
+
+// JS back <br>
+backLinkConfig = Some(BackLinkConfig.JsBack)
+
+// explicit URL <br>
+backLinkConfig = Some(BackLinkConfig.UrlBack("/previous-page"))
+
+// no back link <br>
+backLinkConfig = None
+
 ## Working example
 
 Clone https://github.com/hmrc/single-customer-account-frontend for a working example of the Wrapper being integrated with a standard HMRC MDTP frontend. `HomeController`

--- a/sca-wrapper-play-30/src/main/scala/uk/gov/hmrc/sca/config/BackLinkConfig.scala
+++ b/sca-wrapper-play-30/src/main/scala/uk/gov/hmrc/sca/config/BackLinkConfig.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.sca.config
+
+sealed trait BackLinkConfig {
+  val isJsBack: Boolean      = false
+  val urlOpt: Option[String] = None
+}
+
+object BackLinkConfig {
+  case object JsBack extends BackLinkConfig {
+    override val isJsBack: Boolean = true
+  }
+  case class UrlBack(url: String) extends BackLinkConfig {
+    override val urlOpt: Option[String] = Some(url)
+  }
+}

--- a/sca-wrapper-play-30/src/main/scala/uk/gov/hmrc/sca/services/WrapperService.scala
+++ b/sca-wrapper-play-30/src/main/scala/uk/gov/hmrc/sca/services/WrapperService.scala
@@ -23,7 +23,7 @@ import play.twirl.api.{Html, HtmlFormat}
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage.ServiceURLs
 import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl.idFunctor
 import uk.gov.hmrc.play.bootstrap.binders.{OnlyRelative, RedirectUrl}
-import uk.gov.hmrc.sca.config.AppConfig
+import uk.gov.hmrc.sca.config.{AppConfig, BackLinkConfig}
 import uk.gov.hmrc.sca.models._
 import uk.gov.hmrc.sca.utils.{Keys, WebchatUtil}
 import uk.gov.hmrc.sca.views.html.{PtaMenuBar, StandardScaLayout}
@@ -51,23 +51,18 @@ class WrapperService @Inject() (
     serviceURLs: ServiceURLs,
     serviceNameKey: Option[String] = appConfig.serviceNameKey,
     sidebarContent: Option[Html] = None,
-    @deprecated("Please use appConfig for this setting rather than passing it as a parameter.", since = "3.0.0")
-    timeOutUrl: Option[String] = appConfig.timeOutUrl,
-    @deprecated("Please use appConfig for this setting rather than passing it as a parameter.", since = "3.0.0")
-    keepAliveUrl: String = appConfig.keepAliveUrl,
-    showBackLinkJS: Boolean = false,
-    backLinkUrl: Option[String] = None,
+    backLinkConfig: Option[BackLinkConfig] = None,
     scripts: Seq[HtmlFormat.Appendable] = Seq.empty,
     styleSheets: Seq[HtmlFormat.Appendable] = Seq.empty,
     bannerConfig: BannerConfig = defaultBannerConfig,
     optTrustedHelper: Option[TrustedHelper] = None,
     fullWidth: Boolean = true,
-    hideMenuBar: Boolean = false,
     disableSessionExpired: Boolean = appConfig.disableSessionExpired
   )(implicit messages: Messages, requestHeader: RequestHeader): HtmlFormat.Appendable = {
 
     val useNewServiceNavigation: Boolean = requestHeader.attrs.get(UseServiceNavigation).contains(true)
 
+    val hideMenuBar                             = requestHeader.attrs.get(Keys.wrapperIsAuthenticatedKey).contains(false)
     val ptaMenuConfigOpt: Option[PtaMenuConfig] =
       if (hideMenuBar) None else Some(sortMenuItemConfig(serviceURLs.signOutUrl))
 
@@ -109,10 +104,7 @@ class WrapperService @Inject() (
       serviceNameKey = serviceNameKey,
       pageTitle = pageTitle,
       sidebarContent = sidebarContent,
-      timeOutUrl = timeOutUrl,
-      keepAliveUrl = keepAliveUrl,
-      showBackLinkJS = showBackLinkJS,
-      backLinkUrl = backLinkUrl,
+      backLinkConfig = backLinkConfig,
       showSignOutInHeader = showSignOutInHeader,
       scripts = scripts ++ webchatUtil.getWebchatScripts,
       styleSheets = styleSheets,

--- a/sca-wrapper-play-30/src/main/twirl/uk/gov/hmrc/sca/views/StandardScaLayout.scala.html
+++ b/sca-wrapper-play-30/src/main/twirl/uk/gov/hmrc/sca/views/StandardScaLayout.scala.html
@@ -14,19 +14,17 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.sca.models.TrustedHelper
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.servicenavigation.{ServiceNavigation, ServiceNavigationItem}
 @import uk.gov.hmrc.hmrcfrontend.config.ContactFrontendConfig
+@import uk.gov.hmrc.hmrcfrontend.config.ServiceNavigationCanBeControlledByRequestAttr.UseServiceNavigation
 @import uk.gov.hmrc.hmrcfrontend.views.config.StandardAlphaBanner
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage.{HmrcStandardPageParams, ServiceURLs, TemplateOverrides}
-@import uk.gov.hmrc.sca.config.AppConfig
-@import uk.gov.hmrc.sca.models.{AttorneyBanner, BannerConfig, PtaMenuConfig, UrBannerDetails}
-@import uk.gov.hmrc.sca.utils.Keys
+@import uk.gov.hmrc.sca.config.{AppConfig, BackLinkConfig}
+@import uk.gov.hmrc.sca.models.{AttorneyBanner, BannerConfig, PtaMenuConfig, TrustedHelper, UrBannerDetails}
 @import uk.gov.hmrc.sca.views.html._
 @import uk.gov.hmrc.sca.views.html.components.FullWidthMainContent
-@import uk.gov.hmrc.hmrcfrontend.config.ServiceNavigationCanBeControlledByRequestAttr.UseServiceNavigation
 
 @this(
         appConfig: AppConfig,
@@ -53,10 +51,7 @@
         serviceNameKey: Option[String],
         pageTitle: Option[String],
         sidebarContent: Option[Html],
-        timeOutUrl: Option[String],
-        keepAliveUrl: String,
-        showBackLinkJS: Boolean,
-        backLinkUrl: Option[String],
+        backLinkConfig: Option[BackLinkConfig],
         showSignOutInHeader: Boolean,
         scripts: Seq[HtmlFormat.Appendable],
         styleSheets: Seq[HtmlFormat.Appendable],
@@ -79,9 +74,9 @@
     @hmrcTimeoutDialogHelper(
         timeout         = Some(appConfig.timeout),
         countdown       = Some(appConfig.countdown),
-        keepAliveUrl    = Some(keepAliveUrl),
+        keepAliveUrl    = Some(appConfig.keepAliveUrl),
         signOutUrl      = serviceURLs.signOutUrl.getOrElse("#"),
-        timeoutUrl      = timeOutUrl,
+        timeoutUrl      = appConfig.timeOutUrl,
         synchroniseTabs = Some(appConfig.synchroniseTabs)
     )
 }
@@ -128,28 +123,32 @@
 }
 
 @defining(appConfig.welshToggle && !useNewServiceNavigation) { welshEnabled =>
-    @if(showBackLinkJS || backLinkUrl.isDefined ) {
-        <div class="govuk-grid-row">
-            @if(showBackLinkJS){
-                <div class="govuk-grid-column-one-half">
-                    <div class="govuk-!-display-inline-block js-enabled">
-                    @govukBackLink(BackLink.mimicsBrowserBackButtonViaJavaScript)
-                    </div>
-                </div>
-            } else {
-                <div class="govuk-grid-column-one-half">
-                @govukBackLink(BackLink.withDefaultText(backLinkUrl.getOrElse("#")))
-                </div>
-            }
-            <div class="govuk-grid-column-one-half">
+    @backLinkConfig match {
+        case None => {
             @if(welshEnabled) {
                 @hmrcLanguageSelectHelper()
             }
+        }
+        case Some(blc) => {
+            <div class="govuk-grid-row">
+                @if(blc.isJsBack) {
+                    <div class="govuk-grid-column-one-half">
+                        <div class="govuk-!-display-inline-block js-enabled">
+                        @govukBackLink(BackLink.mimicsBrowserBackButtonViaJavaScript)
+                        </div>
+                    </div>
+                }
+                @for(url <- blc.urlOpt) {
+                    <div class="govuk-grid-column-one-half">
+                    @govukBackLink(BackLink.withDefaultText(url))
+                    </div>
+                }
+                <div class="govuk-grid-column-one-half">
+                    @if(welshEnabled) {
+                        @hmrcLanguageSelectHelper()
+                    }
+                </div>
             </div>
-        </div>
-    } else {
-        @if(welshEnabled) {
-            @hmrcLanguageSelectHelper()
         }
     }
 }

--- a/sca-wrapper-play-30/src/test/scala/services/WrapperServiceSpec.scala
+++ b/sca-wrapper-play-30/src/test/scala/services/WrapperServiceSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.hmrcfrontend.config.ServiceNavigationCanBeControlledByRequest
 import uk.gov.hmrc.sca.models.TrustedHelper
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage.ServiceURLs
 import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
-import uk.gov.hmrc.sca.config.AppConfig
+import uk.gov.hmrc.sca.config.{AppConfig, BackLinkConfig}
 import uk.gov.hmrc.sca.connectors.ScaWrapperDataConnector
 import uk.gov.hmrc.sca.models._
 import uk.gov.hmrc.sca.services.WrapperService
@@ -101,7 +101,6 @@ class WrapperServiceSpec extends BaseSpec {
       when(mockAppConfig.showBetaBanner).thenReturn(false)
       when(mockAppConfig.showHelpImproveBanner).thenReturn(true)
       when(mockAppConfig.serviceNameKey).thenReturn(Some("Default-Service-Name-Key"))
-      when(mockAppConfig.keepAliveUrl).thenReturn("/refresh-session")
       when(mockAppConfig.disableSessionExpired).thenReturn(false)
       when(mockWebchatUtil.getWebchatScripts(any())).thenReturn(Seq.empty[Html])
 
@@ -114,10 +113,7 @@ class WrapperServiceSpec extends BaseSpec {
         serviceNameKey = serviceNameKeyCaptor.capture(),
         pageTitle = pageTitleCaptor.capture(),
         sidebarContent = sideBarContentCaptor.capture(),
-        timeOutUrl = timeOutUrlCaptor.capture(),
-        keepAliveUrl = keepAliveUrlCaptor.capture(),
-        showBackLinkJS = showBackLinkJSCaptor.capture(),
-        backLinkUrl = backLinkUrlCaptor.capture(),
+        backLinkConfig = backLinkConfigCaptor.capture(),
         showSignOutInHeader = showSignOutInHeaderCaptor.capture(),
         scripts = scriptsCaptor.capture(),
         styleSheets = styleSheetsCaptor.capture(),
@@ -133,7 +129,6 @@ class WrapperServiceSpec extends BaseSpec {
       verify(mockAppConfig, times(1)).showBetaBanner
       verify(mockAppConfig, times(1)).showHelpImproveBanner
       verify(mockAppConfig, times(1)).serviceNameKey
-      verify(mockAppConfig, times(1)).keepAliveUrl
       verify(mockAppConfig, times(1)).disableSessionExpired
       verify(mockAppConfig, times(0)).helpImproveBannerUrl
       verify(mockWebchatUtil, times(1)).getWebchatScripts(any())
@@ -145,9 +140,7 @@ class WrapperServiceSpec extends BaseSpec {
       serviceNameKeyCaptor.getValue mustBe Some("Default-Service-Name-Key")
       pageTitleCaptor.getValue mustBe None
       sideBarContentCaptor.getValue mustBe None
-      keepAliveUrlCaptor.getValue mustBe "/refresh-session"
-      showBackLinkJSCaptor.getValue mustBe false
-      backLinkUrlCaptor.getValue mustBe None
+      backLinkConfigCaptor.getValue mustBe None
       showSignOutInHeaderCaptor.getValue mustBe false
       scriptsCaptor.getValue mustBe Seq.empty
       styleSheetsCaptor.getValue mustBe Seq.empty
@@ -178,7 +171,6 @@ class WrapperServiceSpec extends BaseSpec {
       when(mockAppConfig.showBetaBanner).thenReturn(false)
       when(mockAppConfig.showHelpImproveBanner).thenReturn(true)
       when(mockAppConfig.serviceNameKey).thenReturn(Some("Default-Service-Name-Key"))
-      when(mockAppConfig.keepAliveUrl).thenReturn("/refresh-session")
       when(mockAppConfig.disableSessionExpired).thenReturn(false)
       when(mockWebchatUtil.getWebchatScripts(any())).thenReturn(Seq.empty[Html])
 
@@ -195,10 +187,7 @@ class WrapperServiceSpec extends BaseSpec {
         serviceNameKey = serviceNameKeyCaptor.capture(),
         pageTitle = pageTitleCaptor.capture(),
         sidebarContent = sideBarContentCaptor.capture(),
-        timeOutUrl = timeOutUrlCaptor.capture(),
-        keepAliveUrl = keepAliveUrlCaptor.capture(),
-        showBackLinkJS = showBackLinkJSCaptor.capture(),
-        backLinkUrl = backLinkUrlCaptor.capture(),
+        backLinkConfig = backLinkConfigCaptor.capture(),
         showSignOutInHeader = showSignOutInHeaderCaptor.capture(),
         scripts = scriptsCaptor.capture(),
         styleSheets = styleSheetsCaptor.capture(),
@@ -220,9 +209,7 @@ class WrapperServiceSpec extends BaseSpec {
       serviceNameKeyCaptor.getValue mustBe Some("Default-Service-Name-Key")
       pageTitleCaptor.getValue mustBe None
       sideBarContentCaptor.getValue mustBe None
-      keepAliveUrlCaptor.getValue mustBe "/refresh-session"
-      showBackLinkJSCaptor.getValue mustBe false
-      backLinkUrlCaptor.getValue mustBe None
+      backLinkConfigCaptor.getValue mustBe None
       showSignOutInHeaderCaptor.getValue mustBe false
       scriptsCaptor.getValue mustBe Seq.empty
       styleSheetsCaptor.getValue mustBe Seq.empty
@@ -257,7 +244,6 @@ class WrapperServiceSpec extends BaseSpec {
       when(mockAppConfig.showBetaBanner).thenReturn(false)
       when(mockAppConfig.showHelpImproveBanner).thenReturn(false)
       when(mockAppConfig.serviceNameKey).thenReturn(Some("Default-Service-Name-Key"))
-      when(mockAppConfig.keepAliveUrl).thenReturn("/refresh-session")
       when(mockAppConfig.disableSessionExpired).thenReturn(false)
       when(mockWebchatUtil.getWebchatScripts(any())).thenReturn(Seq.empty[Html])
 
@@ -270,10 +256,7 @@ class WrapperServiceSpec extends BaseSpec {
         serviceNameKey = any(),
         pageTitle = any(),
         sidebarContent = any(),
-        timeOutUrl = any(),
-        keepAliveUrl = any(),
-        showBackLinkJS = any(),
-        backLinkUrl = any(),
+        backLinkConfig = any(),
         showSignOutInHeader = any(),
         scripts = any(),
         styleSheets = any(),
@@ -321,7 +304,6 @@ class WrapperServiceSpec extends BaseSpec {
       when(mockAppConfig.showBetaBanner).thenReturn(false)
       when(mockAppConfig.showHelpImproveBanner).thenReturn(true)
       when(mockAppConfig.serviceNameKey).thenReturn(Some("Default-Service-Name-Key"))
-      when(mockAppConfig.keepAliveUrl).thenReturn("/refresh-session")
       when(mockAppConfig.disableSessionExpired).thenReturn(false)
       when(mockWebchatUtil.getWebchatScripts(any())).thenReturn(Seq.empty[Html])
 
@@ -334,10 +316,7 @@ class WrapperServiceSpec extends BaseSpec {
         serviceNameKey = any(),
         pageTitle = any(),
         sidebarContent = any(),
-        timeOutUrl = any(),
-        keepAliveUrl = any(),
-        showBackLinkJS = any(),
-        backLinkUrl = any(),
+        backLinkConfig = any(),
         showSignOutInHeader = any(),
         scripts = any(),
         styleSheets = any(),
@@ -369,7 +348,6 @@ class WrapperServiceSpec extends BaseSpec {
       when(mockAppConfig.showBetaBanner).thenReturn(false)
       when(mockAppConfig.showHelpImproveBanner).thenReturn(true)
       when(mockAppConfig.serviceNameKey).thenReturn(Some("Default-Service-Name-Key"))
-      when(mockAppConfig.keepAliveUrl).thenReturn("/refresh-session")
       when(mockAppConfig.disableSessionExpired).thenReturn(false)
       when(mockWebchatUtil.getWebchatScripts(any())).thenReturn(Seq.empty[Html])
 
@@ -382,10 +360,7 @@ class WrapperServiceSpec extends BaseSpec {
         serviceNameKey = serviceNameKeyCaptor.capture(),
         pageTitle = pageTitleCaptor.capture(),
         sidebarContent = sideBarContentCaptor.capture(),
-        timeOutUrl = timeOutUrlCaptor.capture(),
-        keepAliveUrl = keepAliveUrlCaptor.capture(),
-        showBackLinkJS = showBackLinkJSCaptor.capture(),
-        backLinkUrl = backLinkUrlCaptor.capture(),
+        backLinkConfig = backLinkConfigCaptor.capture(),
         showSignOutInHeader = showSignOutInHeaderCaptor.capture(),
         scripts = scriptsCaptor.capture(),
         styleSheets = styleSheetsCaptor.capture(),
@@ -525,10 +500,8 @@ object WrapperServiceSpec {
   val pageTitleCaptor: ArgumentCaptor[Option[String]]                          = ArgumentCaptor.forClass(classOf[Option[String]])
   val sideBarContentCaptor: ArgumentCaptor[Option[Html]]                       = ArgumentCaptor.forClass(classOf[Option[Html]])
   val signoutUrlCaptor: ArgumentCaptor[Option[String]]                         = ArgumentCaptor.forClass(classOf[Option[String]])
-  val timeOutUrlCaptor: ArgumentCaptor[Option[String]]                         = ArgumentCaptor.forClass(classOf[Option[String]])
-  val keepAliveUrlCaptor: ArgumentCaptor[String]                               = ArgumentCaptor.forClass(classOf[String])
-  val showBackLinkJSCaptor: ArgumentCaptor[Boolean]                            = ArgumentCaptor.forClass(classOf[Boolean])
-  val backLinkUrlCaptor: ArgumentCaptor[Option[String]]                        = ArgumentCaptor.forClass(classOf[Option[String]])
+  val backLinkConfigCaptor: ArgumentCaptor[Option[BackLinkConfig]]             =
+    ArgumentCaptor.forClass(classOf[Option[BackLinkConfig]])
   val showSignOutInHeaderCaptor: ArgumentCaptor[Boolean]                       = ArgumentCaptor.forClass(classOf[Boolean])
   val scriptsCaptor: ArgumentCaptor[Seq[HtmlFormat.Appendable]]                =
     ArgumentCaptor.forClass(classOf[Seq[HtmlFormat.Appendable]])

--- a/sca-wrapper-play-30/src/test/scala/views/StandardScaLayoutViewSpec.scala
+++ b/sca-wrapper-play-30/src/test/scala/views/StandardScaLayoutViewSpec.scala
@@ -22,6 +22,7 @@ import play.twirl.api.Html
 import uk.gov.hmrc.hmrcfrontend.config.ServiceNavigationCanBeControlledByRequestAttr.UseServiceNavigation
 import uk.gov.hmrc.sca.models.TrustedHelper
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage.ServiceURLs
+import uk.gov.hmrc.sca.config.BackLinkConfig
 import uk.gov.hmrc.sca.models.{BannerConfig, PtaMenuConfig, UrBannerDetails}
 import uk.gov.hmrc.sca.views.html.StandardScaLayout
 import utils.ViewBaseSpec
@@ -35,8 +36,7 @@ class StandardScaLayoutViewSpec extends ViewBaseSpec {
 
   private def createView(
     sidebarContent: Option[Html] = None,
-    showBackLinkJS: Boolean = false,
-    backLinkUrl: Option[String] = None,
+    backLinkConfig: Option[BackLinkConfig] = None,
     showSignOutInHeader: Boolean = false,
     menuConfig: Option[PtaMenuConfig] = None,
     serviceURLs: ServiceURLs = ServiceURLs(
@@ -59,10 +59,7 @@ class StandardScaLayoutViewSpec extends ViewBaseSpec {
       serviceNameKey = Some("Service-Name-Key"),
       pageTitle = Some("Page-Title"),
       sidebarContent = sidebarContent,
-      timeOutUrl = Some("TimeOut-Url"),
-      keepAliveUrl = "Keep-Alive-Url",
-      showBackLinkJS = showBackLinkJS,
-      backLinkUrl = backLinkUrl,
+      backLinkConfig = backLinkConfig,
       showSignOutInHeader = showSignOutInHeader,
       scripts = Seq(Html("<script src=/customscript.js></script>")),
       styleSheets = Seq(Html("<link href=/customStylesheet rel=stylesheet/>")),
@@ -98,9 +95,6 @@ class StandardScaLayoutViewSpec extends ViewBaseSpec {
       document.getElementById("menu.right.3").attr("href") mustBe "pertaxUrl-signout-feedback-PERTAX"
       document.select(".govuk-skip-link").text() mustBe "Skip to main content"
 
-      document
-        .getElementsByAttributeValue("name", "hmrc-timeout-dialog")
-        .attr("data-keep-alive-url") mustBe "Keep-Alive-Url"
       document.getElementsByAttributeValue("name", "hmrc-timeout-dialog").attr("data-sign-out-url") mustBe "Signout-Url"
       document
         .getElementsByAttributeValue("name", "hmrc-timeout-dialog")
@@ -165,7 +159,7 @@ class StandardScaLayoutViewSpec extends ViewBaseSpec {
     }
 
     "return a Wrapper layout when there is a backlinkUrl in English" in {
-      val document = asDocument(createView(backLinkUrl = Some("backlink-url")).toString())
+      val document = asDocument(createView(backLinkConfig = Some(BackLinkConfig.UrlBack("backlink-url"))).toString())
 
       document.getElementsByAttributeValue("href", "backlink-url").text() mustBe "Back"
     }
@@ -262,10 +256,7 @@ class StandardScaLayoutViewSpec extends ViewBaseSpec {
         serviceNameKey = Some("Service-Name-Key"),
         pageTitle = Some("Page-Title"),
         sidebarContent = None,
-        timeOutUrl = Some("TimeOut-Url"),
-        keepAliveUrl = "Keep-Alive-Url",
-        showBackLinkJS = false,
-        backLinkUrl = None,
+        backLinkConfig = None,
         showSignOutInHeader = false,
         scripts = Seq(Html("<script src=/customscript.js></script>")),
         styleSheets = Seq(Html("<link href=/customStylesheet rel=stylesheet/>")),


### PR DESCRIPTION
## Migrating to the next major version

### `hideMenuBar` removed
The menu is now shown/hidden automatically based on auth state set by `WrapperDataAttributesFilter`.
- If you passed `hideMenuBar = true` for unauthenticated pages: no action needed, this is now automatic.
- If you passed `hideMenuBar = true` on an authenticated page: this is no longer supported — the menu will always show for authenticated users.

### `timeOutUrl` and `keepAliveUrl` removed as parameters
These are now read from config only. Remove them from your `standardScaLayout()` call.

### `showBackLinkJS` / `backLinkUrl` replaced by `BackLinkConfig`

// JS back
backLinkConfig = Some(BackLinkConfig.JsBack)

// explicit URL
backLinkConfig = Some(BackLinkConfig.UrlBack("/previous-page"))

// no back link
backLinkConfig = None

## These changes impacted to the following services :

pertax-frontend 
cocar-frontend
nisp-frontend 
tai-frontend
find-my-nino-add-to-wallet-frontend 
find-your-national-insurance-number-frontend
child-benefit-view-frontend
taxcalc-frontend 
tamc-frontend 
benefits-frontend 
c2ni-frontend
employee-wfh-expenses-frontend 
repayments-frontend 
tax-summaries-frontend 
low-earners-pensions-payment  
single-customer-account-frontend 
low-earners-pensions-payment-frontend 
fandf-frontend 
employee-expenses-frontend
tracking-frontend 
preferences-frontend
professional-subscriptions-frontend 
nisp-modelling-frontend 